### PR TITLE
179 program invocation is reversed

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ npm install
 * Once you've installed the dependencies, you can run the program by using the following command:
 
 ```
-npm start
+npm start --cli
 ```
 
 ### GUI
@@ -66,10 +66,11 @@ cd 2023sp-420-Maryjane
 npm install
 ```
 
-  * Once you've installed the dependencies, you can run up the GUI process by using the following command:
+  * Once you've installed the dependencies, you can run the GUI by using the following command:
+  
   
 ```
-npm run gui
+npm start
 ```
 
   * This command will make two links appear in the terminal under the "Available on" section (Picture example below). Use CNTRL-Click (Windows) or cmd-Click (MAC) on either of these links to start up the GUI:

--- a/package.json
+++ b/package.json
@@ -4,9 +4,11 @@
   "description": "A Spelling Bee App made in JavaScript for CSCI 420: Software Enginnerring at Millersville University.",
   "main": "initCLI.js",
   "scripts": {
-    "start": "node src/initCLI.js",
+    "start": "npm run start:conditional",
+    "start:gui": "browserify --standalone global src/initGUI.js -o bundle.js && http-server -p 8081",
+    "start:cli": "node src/initCLI.js",
+    "start:conditional": "if [ \"$npm_config_cli\" == \"true\" ]; then npm run start:cli; else npm run start:gui; fi",
     "test": "jest",
-    "gui": "browserify --standalone global src/initGUI.js -o bundle.js && http-server -p 8081",
     "build": "browserify --standalone global src/initGUI.js -o bundle.js"
   },
   "repository": {

--- a/src/README.md
+++ b/src/README.md
@@ -16,7 +16,7 @@ node src/app.js
 or from any folder in `2023-420-MARYJANE`
 
 ```
-npm start
+npm start --cli
 ```
 
 ## Launching the GUI


### PR DESCRIPTION
- I added a conditional statement to the npm start command so that the program invocation can be reversed. So now the npm start command will open the GUI and npm start --cli will open the CLI
- I also updated the README and developer README
- closes #179 